### PR TITLE
link to clojurians where ppl can sign up

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -10,7 +10,7 @@ Resources for developers using ClojureScript to build React Native apps.
 
 ## Discussion
 
-* Slack: `#cljsrn` channel in [Clojurians](https://clojurians.slack.com) Slack.
+* Slack: `#cljsrn` channel in [Clojurians](http://clojurians.net) Slack.
 * IRC: `#clojurescript` channel on [freenode.net](https://freenode.net)
 
 ## Using


### PR DESCRIPTION
When i clicked the slack link directly (clojurians.slack.com), it wasn't obvious how to actually sign up until a friend pointed me at http://clojurians.net.  Seems like it would be more reasonable to point new people to the latter link.