### PR TITLE
More talk links

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -61,6 +61,7 @@ Slides, demos, talks, _etc._ pertaining to ClojureScript with React Native and a
 - [Using ClojureScript to Live-Code Mobile Graphics](https://www.youtube.com/watch?v=FFKiYrvB1-0) <span style='font-size:80%'>(2017-06-09 — Nikhilesh Sigatapu)</span>
 - [React Native and ClojureScript - will it blend?](https://www.youtube.com/watch?v=wHgfjUQFRJU) <span style='font-size:80%'>(2017-05-08 — Oskars Liukis)</span>
 - [ClojureScript in Your Pocket](https://www.youtube.com/watch?v=tHQAMrShHu8) <span style='font-size:80%'>(2017-03-31 — Dom Kiva-Meyer, Lily M. Goh)</span>
+- [From zero to app in six weeks](https://www.youtube.com/watch?v=rOcT1Lp94J4) <span style='font-size:80%'>(2017-02-25 - Damiano Rühl)</span>
 - [On iOS with React Native and Clojurescript](https://vimeo.com/191066643) <span style='font-size:80%'>(2016-11-10 — Jelle Akkerman)</span>
 - [Native mobile apps with ClojureScript](https://www.youtube.com/watch?v=6IYm34nDL64) <span style='font-size:80%'>(2016-09-16 — Viktor Eriksson)</span>
 - [Experience report: Clojure on iOS with React Native](https://www.youtube.com/watch?v=UHRITqJGadU) <span style='font-size:80%'>(2016-06-02 — Jelle Akkerman)</span>

--- a/src/index.md
+++ b/src/index.md
@@ -57,6 +57,7 @@ Slides, demos, talks, _etc._ pertaining to ClojureScript with React Native and a
 
 - [Building Mobile Applications with Clojurescript](https://singaporeinformer.com/293607/building-mobile-applications-with-clojurescript-singapore-clojure-meetup-singapore-video/) <span style='font-size:80%'>(2018-04-19 — Binny Arora)</span>
 - [Functional Mobility: React Native with ClojureScript](http://increasinglyfunctional.com/2017/10/06/clojurescript-react-native-talk/) <span style='font-size:80%'>(2017-10-06 — Joshua Miller)</span>
+- [REPL driven mobile development with Clojure(script)](https://www.youtube.com/watch?v=toGEegAzrZA) <span style='font-size:80%'>(2017-09-13 - Srihari Sriraman)</span>
 - [Using Clojurescript to launch iOS/Android apps to 1M users](https://youtu.be/ELM_eKZXl3M) <span style='font-size:80%'>(2017-06-09 — Emin Hasanov)</span>
 - [Using ClojureScript to Live-Code Mobile Graphics](https://www.youtube.com/watch?v=FFKiYrvB1-0) <span style='font-size:80%'>(2017-06-09 — Nikhilesh Sigatapu)</span>
 - [React Native and ClojureScript - will it blend?](https://www.youtube.com/watch?v=wHgfjUQFRJU) <span style='font-size:80%'>(2017-05-08 — Oskars Liukis)</span>


### PR DESCRIPTION
Added links to two more talks from last year.

The first one is from :clojureD 2017 http://clojured.de/archiv/schedule-2017/

and the second one is Fragments 2017 conference from India:  https://fragments.in/2017/