### PR TITLE
Added react-native-figwheel-bridge

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -19,6 +19,10 @@ Resources for developers using ClojureScript to build React Native apps.
 
 ## Using
 
+### react-native-figwheel-bridge
+
+[react-native-figwheel-bridge](https://github.com/bhauman/react-native-figwheel-bridge) is a simple approach to setup React Native with ClojureScript + Figwheel + REPL on top of a standard React Native project. Follow the readme, the approach seems to work great as described.  
+
 ### Re-Natal
 
 [Re-Natal](https://github.com/drapanjanas/re-natal) is the most popular and most actively developed. The consensus on #cljsrn slack channel is that it's probably the way to go. It supports up-to-date versions of React Native, Reagent and Om Next, iOS and Android, Figwheel, and has a nice way to require native packages and static images.

--- a/src/index.md
+++ b/src/index.md
@@ -106,7 +106,6 @@ Apps built using ClojureScript and React Native.
 - [webMailReader](http://fessguid.com): Using React Native under the hood, with part of business logic in ClojureScript.
 - [QTTT](https://github.com/mfikes/qttt): A port of Luke Vanderhart's web app to use Om on React Native. [Try it online](https://appetize.io/app/8kap5c0m9r3wjjdm45c416rbug?device=iphone5s&scale=75&orientation=portrait&osVersion=8.4).
 - Snapability ([iOS](https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=1124758443&mt=8) / [Android](https://play.google.com/store/apps/details?id=net.snapability)): An OCR app built with re-natal and re-frame.
-- [Hush](https://goo.gl/fny7Q9): Make-up store on your phone - 100% React Native app built using ClojureScript + Om Next
 - [Status](https://status.im): a web3 browser, messenger, and gateway to a decentralised world of Ethereum. re-natal + re-frame + cljs + golang
 - [FullContact](https://fullcontact.com): Contact management apps that help you be awesome with people. Parts of the apps built with React Native + ClojureScript + re-natal + re-frame + figwheel
 - [Riverford](https://itunes.apple.com/gb/app/riverford/id1305077010?mt=8): An app for managing your Riverford order of seasonal, organic veg. App built with React Native + ClojureScript + re-frame + expo


### PR DESCRIPTION
Added the approach as described in https://github.com/bhauman/react-native-figwheel-bridge which seems to work great.

I like this approach because it's very barebones without much extra fluff and gets everything working just like re-natal did with Figwheel and REPL. It works on any version of React Native (tested on the newest, 0.61), it does not bundle React Native with itself, it's just a library you add to an existing/new React Native project you create the standard way via the react-native utility. One thing that can be improved there is the description of how to build for production (I got production builds working, and submitted a comment here: https://github.com/bhauman/react-native-figwheel-bridge/issues/4#issuecomment-553288868 

As a side note: I didn't want to edit this myself but the re-natal project doesn't seem to be very maintained at this moment (last commit was in May 2019) and it's on a somewhat old version of React Native currently (pre 0.60).

Also removed an app which I worked on some time ago but it's no longer live.